### PR TITLE
Listing Plasma Repos as suggested in call #3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Plasma
-Below is an list of Ethereum related second-layer side-chain designs which are currently undergoing development on GitHub.
+Below is an list of Ethereum related second-layer side-chain designs which are currently undergoing development on GitHub. For a comprehensive one-stop Plasma shop, which includes current research as well as learning and development resources, please visit [Learn Plasma](http://www.learnplasma.org/).
 
 ## Bankex
 [Bankex](https://github.com/BANKEX/PlasmaParentContract)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Below is an list of Ethereum related second-layer side-chain designs which are c
 ## FastX Protocol, forked from Omisego's Plasma MVP
 [MVP](https://github.com/FastXProtocol/plasma-mvp)
 
-## Blockchain at Berkeley
-[Plasma Debit](https://github.com/FourthState)
+## FourthState Labs
+[Plasma MVP](https://github.com/FourthState)
 
 ## Kelvin Fichter
 [More Minimal Plasma](https://github.com/kfichter/more-minimal-plasma)

--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# plasma
+# Plasma
+Below is an list of Ethereum related second-layer side-chain designs which are currently undergoing development on GitHub.
+
+## Bankex
+[Bankex](https://github.com/BANKEX/PlasmaParentContract)
+
+## Cosmos, Peg Zone Implementation
+[Cosmos, Peg Zone Implementation](https://github.com/cosmos/peggy)
+
+## Taiwan Team, Javascript implementation of Plasma MVP
+[Taiwan Team, Javascript implementation of Plasma MVP](https://github.com/ethereum-plasma/plasma)
+
+## Blockchain at Berkeley
+[Blockchain at Berkeley, Plasma Debit](https://github.com/FourthState)
+
+## Loom Network
+[Loom Network](https://github.com/loomnetwork/plasma-erc721)
+
+## OmiseGO, Plasma Cash
+[OmiseGO Plasma Cash - GitHub Repository](https://github.com/omisego/plasma-cash)
+
+## OmiseGO, Plasma MVP
+[OmiseGO Plasma MVP - GitHub Repository](https://github.com/omisego/plasma-mvp)
+
+## Voltaire Labs
+[Voltaire Labs](https://github.com/voltairelabs/plasma)
+
+## Wolk
+[Wolk](https://github.com/wolkdb/deepblockchains/tree/master/Plasmacash)
+
+Please note: The list is in alphabetical order (based on the GitHub repository which houses the code)

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ Below is an list of Ethereum related second-layer side-chain designs which are c
 ## Taiwan Team, Javascript implementation of Plasma MVP
 [Taiwan Team, Javascript implementation of Plasma MVP](https://github.com/ethereum-plasma/plasma)
 
+## FastX Protocol, forked from Omisego's Plasma MVP
+[FastX Protocol](https://github.com/FastXProtocol/plasma-mvp)
+
 ## Blockchain at Berkeley
 [Blockchain at Berkeley, Plasma Debit](https://github.com/FourthState)
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Below is an list of Ethereum related second-layer side-chain designs which are c
 ## Blockchain at Berkeley
 [Blockchain at Berkeley, Plasma Debit](https://github.com/FourthState)
 
+## Kelvin Fichter
+[More Minimal Plasma](https://github.com/kfichter/more-minimal-plasma)
+
 ## Loom Network
 [Loom Network](https://github.com/loomnetwork/plasma-erc721)
 
@@ -31,7 +34,5 @@ Below is an list of Ethereum related second-layer side-chain designs which are c
 ## Voltaire Labs
 [Voltaire Labs](https://github.com/voltairelabs/plasma)
 
-## Wolk
-[Wolk](https://github.com/wolkdb/deepblockchains/tree/master/Plasmacash)
 
 Please note: The list is in alphabetical order (based on the GitHub account which houses the code)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
-# Plasma
-Below is an list of Ethereum related second-layer side-chain designs which are currently undergoing development on GitHub. For a comprehensive one-stop Plasma shop, which includes current research as well as learning and development resources, please visit [Learn Plasma](http://www.learnplasma.org/).
+# Learn Plasma
+For a comprehensive one-stop Plasma shop, which includes current research as well as learning and development resources, please visit [Learn Plasma](http://www.learnplasma.org/).
+
+# Plasma Implementations
+Below is an list of Ethereum related second-layer side-chain designs which are currently undergoing development on GitHub.
 
 ## Bankex
 [Bankex](https://github.com/BANKEX/PlasmaParentContract)

--- a/README.md
+++ b/README.md
@@ -5,31 +5,39 @@ For a comprehensive one-stop Plasma shop, which includes current research as wel
 Below is an list of Ethereum related second-layer side-chain designs which are currently undergoing development on GitHub.
 
 ## Bankex
-[Bankex](https://github.com/BANKEX/PlasmaParentContract)
+[Plasma](https://github.com/BANKEX/PlasmaParentContract)
 
 ## Cosmos, Peg Zone Implementation
-[Cosmos, Peg Zone Implementation](https://github.com/cosmos/peggy)
+[Peg Zone Implementation](https://github.com/cosmos/peggy)
 
 ## Taiwan Team, Javascript implementation of Plasma MVP
-[Taiwan Team, Javascript implementation of Plasma MVP](https://github.com/ethereum-plasma/plasma)
+[Javascript implementation of Plasma MVP](https://github.com/ethereum-plasma/plasma)
 
 ## FastX Protocol, forked from Omisego's Plasma MVP
-[FastX Protocol](https://github.com/FastXProtocol/plasma-mvp)
+[MVP](https://github.com/FastXProtocol/plasma-mvp)
 
 ## Blockchain at Berkeley
-[Blockchain at Berkeley, Plasma Debit](https://github.com/FourthState)
+[Plasma Debit](https://github.com/FourthState)
 
 ## Kelvin Fichter
 [More Minimal Plasma](https://github.com/kfichter/more-minimal-plasma)
 
+## Kyokan
+[MVP](https://github.com/kyokan/plasma)
+
 ## Loom Network
 [Loom Network](https://github.com/loomnetwork/plasma-erc721)
 
-## OmiseGO, Plasma Cash
-[OmiseGO Plasma Cash - GitHub Repository](https://github.com/omisego/plasma-cash)
+## Lucidity
+[Plasma Cash](https://github.com/luciditytech/lucidity-plasma-cash)
+[Plasma Bank](https://github.com/luciditytech/plasma-bank)
+[Plasma MVP](https://github.com/luciditytech/lucidity-plasma)
 
-## OmiseGO, Plasma MVP
-[OmiseGO Plasma MVP - GitHub Repository](https://github.com/omisego/plasma-mvp)
+## OmiseGO
+[Elixir Client Library](https://github.com/omgnetwork/ex_plasma)
+[Plasma Contracts](https://github.com/omgnetwork/plasma-contracts)
+[Plasma Cash](https://github.com/omgnetwork/plasma-cash)
+[Plasma MVP](https://github.com/omgnetwork/plasma-mvp)
 
 ## Voltaire Labs
 [Voltaire Labs](https://github.com/voltairelabs/plasma)

--- a/README.md
+++ b/README.md
@@ -28,4 +28,4 @@ Below is an list of Ethereum related second-layer side-chain designs which are c
 ## Wolk
 [Wolk](https://github.com/wolkdb/deepblockchains/tree/master/Plasmacash)
 
-Please note: The list is in alphabetical order (based on the GitHub repository which houses the code)
+Please note: The list is in alphabetical order (based on the GitHub account which houses the code)


### PR DESCRIPTION
Listing the different second layer side chain projects which are undergoing design and implementation.
I am just listing the GitHub repos for now, perhaps we could also list papers and documentation if you think that is a good idea.
I am happy to source the content, as required.
This is just a start, I will keep a lookout for others which are under development.